### PR TITLE
Add escape description

### DIFF
--- a/src/main/java/seedu/commando/logic/commands/CommandFactory.java
+++ b/src/main/java/seedu/commando/logic/commands/CommandFactory.java
@@ -298,7 +298,7 @@ public class CommandFactory {
         }
 
         if (!sequentialParser.isInputEmpty()) {
-            throw new IllegalValueException(String.format(Messages.INVALID_COMMAND_FORMAT, UndoCommand.COMMAND_WORD));
+            throw new IllegalValueException(String.format(Messages.INVALID_COMMAND_FORMAT, EditCommand.COMMAND_WORD));
         }
 
         return command;

--- a/src/main/java/seedu/commando/logic/commands/CommandFactory.java
+++ b/src/main/java/seedu/commando/logic/commands/CommandFactory.java
@@ -132,6 +132,9 @@ public class CommandFactory {
     }
 
     private Command buildAddCommand() throws IllegalValueException {
+        // Check if quoted title exists
+        Optional<String> quotedTitle = sequentialParser.extractQuotedTitle();
+
         // Extract tags
         Set<Tag> tags = sequentialParser.extractTrailingTags();
 
@@ -141,10 +144,16 @@ public class CommandFactory {
         // Extract due date, if exists
         Optional<DueDate> dueDate = sequentialParser.extractTrailingDueDate();
 
-        // Extract title
-        String title = sequentialParser.extractText().orElseThrow(() -> new IllegalValueException(Messages.MISSING_TODO_TITLE));
-
-        AddCommand command = new AddCommand(new Title(title));
+        // Initialize command
+        // Extract title, if there was no quoted title
+        // Otherwise, use the quoted title
+        AddCommand command;
+        if (quotedTitle.isPresent()) {
+            command = new AddCommand(new Title(quotedTitle.get()));
+        } else {
+            String title = sequentialParser.extractText().orElseThrow(() -> new IllegalValueException(Messages.MISSING_TODO_TITLE));
+            command = new AddCommand(new Title(title));
+        }
 
         // Put in fields
         if (!tags.isEmpty()) {
@@ -256,6 +265,8 @@ public class CommandFactory {
             () -> new IllegalValueException(Messages.MISSING_TODO_ITEM_INDEX)
         );
 
+        Optional<String> quotedTitle = sequentialParser.extractQuotedTitle();
+
         EditCommand command = new EditCommand(index);
 
         // Extract tags
@@ -276,10 +287,19 @@ public class CommandFactory {
             x -> command.dueDate = x
         );
 
-        // Extract title
-        sequentialParser.extractText().ifPresent(title -> {
-            command.title = new Title(title);
-        });
+        // Try to extract title, if there was no quoted title
+        // Otherwise, use the quoted title
+        if (quotedTitle.isPresent()) {
+            command.title = new Title(quotedTitle.get());
+        } else {
+            sequentialParser.extractText().ifPresent(
+                title -> command.title = new Title(title)
+            );
+        }
+
+        if (!sequentialParser.isInputEmpty()) {
+            throw new IllegalValueException(String.format(Messages.INVALID_COMMAND_FORMAT, UndoCommand.COMMAND_WORD));
+        }
 
         return command;
     }

--- a/src/main/java/seedu/commando/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/commando/logic/parser/DateTimeParser.java
@@ -35,6 +35,7 @@ public class DateTimeParser {
     private static final String DateWithLaterAgoRegexString = "((\\d+\\d)|([2-9]))\\s+(days|weeks|months|years)\\s+(later|ago)";
     private static final String DateWithNextRegexString = "next (week|month|year)";
     private static final String TimeNightRegexString = "(this\\s+)?(night|tonight)";
+    private static final String TimeHourRegexString = "(?<hours>\\d{1,2})(?<minutes>\\d{2})h";
 
     private static final String[] supportedDateRegexStrings = new String[] {
         DateWithSlashesRegexString,
@@ -48,7 +49,7 @@ public class DateTimeParser {
 
     private static final String[] supportedTimeRegexStrings = new String[] {
         "(\\d{2})(\\.|:)(\\d{2})",
-        "(\\d{2}):?(\\d{2})h",
+        TimeHourRegexString,
         "(\\d{1,2})(\\.|:)?(\\d{2})?(am|pm)",
         "(this\\s+)?(morning|afternoon|noon|evening|midnight)",
         TimeNightRegexString
@@ -185,11 +186,15 @@ public class DateTimeParser {
             // If matched from the start
             if (matcher.find() && matcher.start() == 0) {
 
+                // Special case: for TimeHourRegexString format,
+                // Change to colon format (natty parses it wrongly when there is no year in the date)
+                if (regexString.equals(TimeHourRegexString)) {
+                    timeString = matcher.group("hours") + ":" + matcher.group("minutes");
+                }
                 // Special case: for TimeNightRegexString format,
                 // Set time to 9pm
-                if (regexString.equals(TimeNightRegexString)) {
+                else if (regexString.equals(TimeNightRegexString)) {
                     timeString = NightLocalTime.toString();
-                    System.out.println(NightLocalTime);
                 } else {
                     timeString = matcher.group().trim();
                 }

--- a/src/test/java/seedu/commando/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/commando/logic/commands/AddCommandTest.java
@@ -164,7 +164,6 @@ public class AddCommandTest {
         String command = "add valid title by 1 Mar 2016 20:01 #tag1 #tag2";
         CommandResult result = logic.execute(command);
         assertFalse(result.hasError());
-
         assertTrue(wasToDoListChangedEventPosted(eventsCollector));
         assertTrue(ifToDoExists(logic,
             new ToDoBuilder("valid title")
@@ -179,8 +178,9 @@ public class AddCommandTest {
 
     @Test
     public void execute_add_emptyTag() throws IllegalValueException {
-        logic.execute("add title #    ");
-
+        CommandResult result = logic.execute("add title #    ");
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
         assertTrue(ifToDoExists(logic,
             new ToDoBuilder("title")
                 .build()));
@@ -188,8 +188,9 @@ public class AddCommandTest {
 
     @Test
     public void execute_add_taskWithFromToBy() throws IllegalValueException {
-        logic.execute("add walk by the beach from here to there");
-
+        CommandResult result = logic.execute("add walk by the beach from here to there");
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
         assertTrue(ifToDoExists(logic,
             new ToDoBuilder("walk by the beach from here to there")
                 .build()));
@@ -197,8 +198,9 @@ public class AddCommandTest {
 
     @Test
     public void execute_add_eventWith2DateRanges() throws IllegalValueException {
-        logic.execute("add walk by the beach from today to tomorrow from 10 Nov 2011 1200h to 11 Dec 2012 1300h");
-
+        CommandResult result = logic.execute("add walk by the beach from today to tomorrow from 10 Nov 2011 1200h to 11 Dec 2012 1300h");
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
         assertTrue(ifToDoExists(logic,
             new ToDoBuilder("walk by the beach from today to tomorrow")
                 .withDateRange(
@@ -260,5 +262,30 @@ public class AddCommandTest {
         assertTrue(result.hasError());
         assertEquals(Messages.MISSING_TODO_DATERANGE_END, result.getFeedback());
         assertFalse(wasToDoListChangedEventPosted(eventsCollector));
+    }
+
+    @Test
+    public void execute_add_quotedTitle() throws IllegalValueException {
+        CommandResult result = logic.execute("add `event from today to tomorrow`");
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
+        assertTrue(ifToDoExists(logic,
+            new ToDoBuilder("event from today to tomorrow")
+                .build()));
+    }
+
+    @Test
+    public void execute_add_trailingTextAfterQuotedTitle() throws IllegalValueException {
+        CommandResult result = logic.execute("add `event from today to` tomorrow");
+        assertTrue(result.hasError());
+        assertFalse(wasToDoListChangedEventPosted(eventsCollector));
+    }
+
+    @Test
+    public void execute_add_emptyQuotedTitle() throws IllegalValueException {
+        CommandResult result = logic.execute("add `  ` from today to tomorrow");
+        assertTrue(result.hasError());
+        assertFalse(wasToDoListChangedEventPosted(eventsCollector));
+        assertEquals(Messages.MISSING_TODO_TITLE, result.getFeedback());
     }
 }

--- a/src/test/java/seedu/commando/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/commando/logic/commands/EditCommandTest.java
@@ -77,6 +77,8 @@ public class EditCommandTest {
     public void execute_edit_title() throws IllegalValueException {
         logic.execute("add title #tag");
 
+        eventsCollector.reset();
+
         String command = "edit 1 new title";
         CommandResult result = logic.execute(command);
         assertFalse(result.hasError());
@@ -140,7 +142,7 @@ public class EditCommandTest {
                 )
                 .build()));
 
-        String command = "edit 1 from 10 Sep " + nextYear + " 12:00 to 21 Sep " + nextYear + " 13:00";
+        String command = "edit 1 from 10 Sep " + nextYear + " 12:15 to 21 Sep " + nextYear + " 13:45";
         CommandResult result = logic.execute(command);
         assertFalse(result.hasError());
 
@@ -148,8 +150,8 @@ public class EditCommandTest {
         assertTrue(ifToDoExists(logic,
             new ToDoBuilder("title")
                 .withDateRange(
-                    LocalDateTime.of(nextYear, 9, 10, 12, 0),
-                    LocalDateTime.of(nextYear, 9, 21, 13, 0)
+                    LocalDateTime.of(nextYear, 9, 10, 12, 15),
+                    LocalDateTime.of(nextYear, 9, 21, 13, 45)
                 )
                 .build()));
     }
@@ -234,5 +236,65 @@ public class EditCommandTest {
                     LocalDateTime.of(2012, 12, 11, 13, 0)
                 )
                 .build()));
+    }
+
+
+    @Test
+    public void execute_edit_quotedTitleWithBy() throws IllegalValueException {
+        logic.execute("add title #tag");
+
+        eventsCollector.reset();
+
+        CommandResult result = logic.execute("edit 1 `by tomorrow`");
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
+        assertTrue(ifToDoExists(logic,
+            new ToDoBuilder("by tomorrow")
+                .withTags("tag")
+                .build()));
+    }
+
+    @Test
+    public void execute_edit_quotedTitleWithFromTo() throws IllegalValueException {
+        logic.execute("add title from 10 Jan " + nextYear + " 12:00 to 21 Jan " + nextYear + " 13:00");
+
+        eventsCollector.reset();
+
+        String command = "edit 1 `from today to tomorrow`"
+            + "from 10 Feb " + nextYear + " 12:15 to 21 Feb " + nextYear + " 13:45";
+        CommandResult result = logic.execute(command);
+        assertFalse(result.hasError());
+        assertTrue(wasToDoListChangedEventPosted(eventsCollector));
+        assertTrue(ifToDoExists(logic,
+            new ToDoBuilder("from today to tomorrow")
+                .withDateRange(
+                    LocalDateTime.of(nextYear, 2, 10, 12, 15),
+                    LocalDateTime.of(nextYear, 2, 21, 13, 45)
+                )
+                .build()));
+    }
+
+    @Test
+    public void execute_edit_trailingTextAfterQuotedTitle() throws IllegalValueException {
+        logic.execute("add title");
+
+        eventsCollector.reset();
+
+        String command = "edit 1 `from today to tomorrow` 13:45";
+        CommandResult result = logic.execute(command);
+        assertTrue(result.hasError());
+        assertFalse(wasToDoListChangedEventPosted(eventsCollector));
+    }
+
+    @Test
+    public void execute_edit_emptyQuotedTitle() throws IllegalValueException {
+        logic.execute("add title");
+
+        eventsCollector.reset();
+
+        CommandResult result = logic.execute("edit 1 ``");
+        assertTrue(result.hasError());
+        assertFalse(wasToDoListChangedEventPosted(eventsCollector));
+        assertEquals(Messages.MISSING_TODO_TITLE, result.getFeedback());
     }
 }

--- a/src/test/java/seedu/commando/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/commando/logic/parser/DateTimeParserTest.java
@@ -87,6 +87,15 @@ public class DateTimeParserTest {
         );
     }
 
+    // Underlying natty doesn't parse this properly
+    @Test
+    public void parseDateTime_DateWithoutYearAndHHmmh()  {
+        assertEquals(
+            LocalDateTime.of(now.getYear(), 10, 31, 19, 19),
+            dateTimeParser.parseDateTime("31 Oct 1919h").orElse(null)
+        );
+    }
+
     @Test
     public void parseDateTime_ordinalFullMonth_HHAm()  {
         assertEquals(


### PR DESCRIPTION
This commit allows the use of backticks to escape command keywords in descriptions.
E.g. >> edit 1 `by tomorrow` would edit a task's description to `by tomorrow` instead of adding a deadline
